### PR TITLE
Using uri.fsPath instead of uri.path for cross-platform compatibility

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,7 +53,7 @@ function openWith(editor: Editor, uri: vscode.Uri) {
 
     const shellType = vscode.env.shell;
     const terminal = vscode.window.createTerminal({
-        name: basename(uri.path),
+        name: basename(uri.fsPath),
         location: vscode.TerminalLocation.Editor,
     });
 
@@ -65,7 +65,7 @@ function openWith(editor: Editor, uri: vscode.Uri) {
      * has done their job.
      */
     setTimeout(() => {
-        terminal.sendText(getOpenWithCommand(editor, uri.path, shellType));
+        terminal.sendText(getOpenWithCommand(editor, uri.fsPath, shellType));
         terminal.show();
     }, SAFETY_TIMEOUT_MS);
 }


### PR DESCRIPTION
On Windows, uri.path is not usable in the context of a file system. One should use uri.fsPath.

![image](https://user-images.githubusercontent.com/194082/198256125-8dbe6572-4bb2-4fce-b7f6-f4517ba3d8b0.png)
